### PR TITLE
Fixes a crash in case PDEVICE_RELATIONS is NULL

### DIFF
--- a/bff/bff.c
+++ b/bff/bff.c
@@ -411,19 +411,19 @@ BffCompleteQueryBusRelations(
         }
 
         if (dr) {
-	        for (i = 0; i < dr->Count; i++) {
-	            NTSTATUS status = BffAddDevice(Device, dr->Objects[i]);
-	            if (!NT_SUCCESS(status)) {
-	                KdPrint(("%s: failed to add a child:%x\n", __FUNCTION__, status));
-	                BffLogError(DeviceObject, IRP_MN_QUERY_DEVICE_RELATIONS, IO_ERR_INTERNAL_ERROR, status);
-	                break;
-	            }
-	        }
+            for (i = 0; i < dr->Count; i++) {
+                NTSTATUS status = BffAddDevice(Device, dr->Objects[i]);
+                if (!NT_SUCCESS(status)) {
+                    KdPrint(("%s: failed to add a child:%x\n", __FUNCTION__, status));
+                    BffLogError(DeviceObject, IRP_MN_QUERY_DEVICE_RELATIONS, IO_ERR_INTERNAL_ERROR, status);
+                    break;
+                }
+            }
         }
         else
         {
-	        KdPrint(("%s: failed to retreive device relations:%x\n", __FUNCTION__, Irp->IoStatus.Status));
-	        BffLogError(DeviceObject, IRP_MN_QUERY_DEVICE_RELATIONS, IO_ERR_INTERNAL_ERROR, Irp->IoStatus.Status);
+            KdPrint(("%s: failed to retreive device relations:%x\n", __FUNCTION__, Irp->IoStatus.Status));
+            BffLogError(DeviceObject, IRP_MN_QUERY_DEVICE_RELATIONS, IO_ERR_INTERNAL_ERROR, Irp->IoStatus.Status);
         }
     }
 

--- a/bff/bff.c
+++ b/bff/bff.c
@@ -410,13 +410,20 @@ BffCompleteQueryBusRelations(
             KeReleaseInStackQueuedSpinLock(&handle);
         }
 
-        for (i = 0; i < dr->Count; i++) {
-            NTSTATUS status = BffAddDevice(Device, dr->Objects[i]);
-            if (!NT_SUCCESS(status)) {
-                KdPrint(("%s: failed to add a child:%x\n", __FUNCTION__, status));
-                BffLogError(DeviceObject, IRP_MN_QUERY_DEVICE_RELATIONS, IO_ERR_INTERNAL_ERROR, status);
-                break;
-            }
+        if (dr) {
+	        for (i = 0; i < dr->Count; i++) {
+	            NTSTATUS status = BffAddDevice(Device, dr->Objects[i]);
+	            if (!NT_SUCCESS(status)) {
+	                KdPrint(("%s: failed to add a child:%x\n", __FUNCTION__, status));
+	                BffLogError(DeviceObject, IRP_MN_QUERY_DEVICE_RELATIONS, IO_ERR_INTERNAL_ERROR, status);
+	                break;
+	            }
+	        }
+        }
+        else
+        {
+	        KdPrint(("%s: failed to retreive device relations:%x\n", __FUNCTION__, Irp->IoStatus.Status));
+	        BffLogError(DeviceObject, IRP_MN_QUERY_DEVICE_RELATIONS, IO_ERR_INTERNAL_ERROR, Irp->IoStatus.Status);
         }
     }
 


### PR DESCRIPTION
I've encountered a crash on my system caused in combination with this fairly dated USB Smart-Card driver:

![image](https://user-images.githubusercontent.com/286631/169448938-05f5a2c2-ac44-40c4-be57-c82a45cc95be.png)

![image](https://user-images.githubusercontent.com/286631/169448873-a0b6c713-a034-4e76-80cd-483f7b809b2a.png)

The crash is caused by `Irp->IoStatus.Information` being `NULL` so I threw in a simple check and log if this case happens.

## WinDbg call stack

```text
2: kd> kc
 # Call Site
00 nt!KeBugCheckEx
01 nt!PspSystemThreadStartup$filt$0
02 nt!_C_specific_handler
03 nt!RtlpExecuteHandlerForException
04 nt!RtlDispatchException
05 nt!KiDispatchException
06 nt!KiExceptionDispatch
07 nt!KiPageFault
08 nssidswap!BffCompleteQueryBusRelations
09 nt!IopfCompleteRequest
0a nt!IofCompleteRequest
0b tusbdbuslt
0c tusbdbuslt
0d nt!IofCallDriver
0e aksup
0f aksup
10 aksup
11 nt!IofCallDriver
12 Wdf01000!FxIrp::CallDriver
13 Wdf01000!FxPkgFdo::_PnpPassDown
14 Wdf01000!FxPkgFdo::PnpQueryDeviceRelations
15 Wdf01000!FxPkgFdo::_PnpQueryDeviceRelations
16 Wdf01000!FxPkgPnp::Dispatch
17 Wdf01000!DispatchWorker
18 Wdf01000!FxDevice::DispatchPreprocessedIrp
19 Wdf01000!imp_WdfDeviceWdmDispatchPreprocessedIrp
1a Wdf01000!PreprocessIrp
1b Wdf01000!DispatchWorker
1c Wdf01000!FxDevice::Dispatch
1d Wdf01000!FxDevice::DispatchWithLock
1e nssidswap!BffDispatchAny
1f nt!IofCallDriver
20 nt!PnpAsynchronousCall
21 nt!PnpSendIrp
22 nt!PnpQueryDeviceRelations
23 nt!PipEnumerateDevice
24 nt!PipProcessDevNodeTree
25 nt!PiRestartDevice
26 nt!PnpDeviceActionWorker
27 nt!ExpWorkerThread
28 nt!PspSystemThreadStartup
29 nt!KiStartSystemThread
```